### PR TITLE
perf: reduce chat time-to-first-token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,21 @@ GITHUB_TOKEN=
 # COHERE_API_KEY=your_cohere_api_key
 
 # ---------------------------------------------
+# CHAT LATENCY TUNING (optional - sensible defaults baked into code)
+# See .agents/docs/chat-latency-pipeline.md
+# ---------------------------------------------
+
+# LLM provider routing on the web chat path. Default 'latency' picks the fastest
+# provider (cuts time-to-first-token ~2-3x) while a code-side quantization allowlist
+# excludes fp4 backends. Set to "" to disable the sort and use OpenRouter default routing.
+# OPENROUTER_SORT=latency
+
+# Provider order for the query embedding (baai/bge-m3). Pinning avoids OpenRouter
+# routing to a slow provider on every request. Comma-separated; set "" to disable.
+# The model is deterministic so pinning does not change retrieval results.
+# OPENROUTER_EMBED_ORDER=SiliconFlow,DeepInfra
+
+# ---------------------------------------------
 # APPLICATION SETTINGS
 # ---------------------------------------------
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -632,6 +632,11 @@ export async function POST(request: Request) {
     // Normalize query for RAG retrieval (handles "Q" → "Quilibrium", misspellings, etc.)
     const userQuery = normalizeQuery(rawUserQuery);
 
+    // Per-phase timing: one `[chat] timing ...` line logged at first token (visible in Vercel
+    // runtime logs). No user text, only milliseconds. Helps spot which stage regresses in prod.
+    const tStart = Date.now();
+    const phases: Record<string, number> = {};
+
     // Stats shortcut: fetch live stats and stream them back, skip RAG entirely
     if (statsRequested) {
       const stream = createUIMessageStream({
@@ -814,6 +819,16 @@ export async function POST(request: Request) {
       writer.write({ type: 'data-error' as const, data: { source, message } });
     };
 
+    // Log per-phase timing once, at the first streamed token. Shared by both the OpenRouter
+    // and Chutes paths so `first_token` reflects real TTFT regardless of provider.
+    let loggedTiming = false;
+    const logTiming = () => {
+      if (loggedTiming) return;
+      loggedTiming = true;
+      const parts = Object.entries(phases).map(([k, v]) => `${k}=${v}ms`).join(' ');
+      console.log(`[chat] timing ${parts} first_token=${Date.now() - tStart}ms`);
+    };
+
     const stream = createUIMessageStream({
       execute: async ({ writer }) => {
         // Debug snapshot: env + request shape, before any work
@@ -847,6 +862,7 @@ export async function POST(request: Request) {
           if (embeddingProvider === 'openrouter' && !openrouterKey) {
             console.warn('Skipping RAG retrieval: OpenRouter API key missing for embeddings.');
           } else {
+            const tRag = Date.now();
             const prepared = await prepareQuery({
               query: userQuery,
               conversationHistory: [],
@@ -857,6 +873,7 @@ export async function POST(request: Request) {
               cohereApiKey: process.env.COHERE_API_KEY,
               priorityDocIds,
             });
+            phases.rag = Date.now() - tRag;
 
             ({ systemPrompt, retrievedChunks: chunks, ragQuality, sources: formattedSources } = prepared);
             const maxSim = chunks.length > 0 ? Math.max(...chunks.map(c => c.similarity)).toFixed(3) : '0';
@@ -979,6 +996,7 @@ export async function POST(request: Request) {
             let isFirstChunk = true;
             for await (const chunk of streamResult.textStream) {
               if (chunk) {
+                logTiming();
                 localReceivedContent = true;
                 receivedAnyContent = true;
                 fullResponseText += chunk;
@@ -1232,6 +1250,7 @@ export async function POST(request: Request) {
           system: systemPrompt,
           messages: llmMessages,
           tools: ragTools,
+          onChunk: () => logTiming(),
           onError: (error) => {
             const msg = error.error instanceof Error ? error.error.message : String(error.error);
             console.error('LLM streaming error:', msg);

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1212,8 +1212,23 @@ export async function POST(request: Request) {
         } // end normal (non-correction) flow
       } else {
         // OpenRouter and other providers: use standard toUIMessageStream()
+        // Provider routing for latency: OpenRouter's default load-balancing can land on a slow
+        // provider (measured TTFT p50 ~4.4s, worst run ~11s). `sort: 'latency'` cuts p50 to ~1.5s
+        // and removes the slow tail. The quantization allowlist excludes fp4 (DeepInfra/AtlasCloud
+        // serve deepseek-v4-flash at fp4 = degraded quality) so the latency sort can't trade
+        // quality for speed. Toggle: OPENROUTER_SORT="" disables the sort via env.
+        const providerSort = process.env.OPENROUTER_SORT ?? 'latency';
+        const openrouterModel =
+          provider === 'openrouter' && providerSort
+            ? (modelProvider as ReturnType<typeof createOpenRouter>)(model, {
+                provider: {
+                  sort: providerSort as 'latency',
+                  quantizations: ['fp8', 'fp16', 'bf16', 'fp32', 'int8', 'unknown'],
+                },
+              })
+            : modelProvider(model);
         const result = streamText({
-          model: modelProvider(model) as Parameters<typeof streamText>[0]['model'],
+          model: openrouterModel as Parameters<typeof streamText>[0]['model'],
           system: systemPrompt,
           messages: llmMessages,
           tools: ragTools,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "sync-discord:status": "tsx scripts/sync-discord/index.ts status",
     "recap-general": "tsx scripts/sync-discord/recap.ts",
     "typecheck": "tsc --noEmit",
+    "measure:latency": "tsx scripts/measure-latency.ts",
     "version:bump": "tsx scripts/version-bump.ts",
     "release": "tsx scripts/release/index.ts",
     "release:prepare": "tsx scripts/release/index.ts prepare",

--- a/scripts/measure-latency.ts
+++ b/scripts/measure-latency.ts
@@ -1,0 +1,81 @@
+/**
+ * Misura la latenza dei singoli stadi della pipeline RAG di /api/chat, chiamandoli
+ * direttamente (senza auth/route). Serve per il baseline e il confronto before/after
+ * (task 2026-07-10-chat-latency-optimization). Nessun valore di env viene stampato.
+ *
+ *   yarn measure:latency
+ *
+ * Nota: i valori assoluti da locale differiscono da Vercel (regione), ma il confronto
+ * relativo before/after è valido.
+ */
+import 'dotenv/config';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { embed } from 'ai';
+import { retrieveWithReranking } from '../src/lib/rag/retriever';
+import { prepareQuery } from '../src/lib/rag/service';
+
+const QUERY = 'How does Quilibrium consensus work and what is the hypergraph?';
+const EMBEDDING_MODEL = process.env.OPENROUTER_EMBEDDING_MODEL || 'baai/bge-m3';
+const median = (xs: number[]) => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+
+async function time(label: string, fn: () => Promise<unknown>, runs = 3): Promise<number> {
+  const ms: number[] = [];
+  for (let i = 0; i < runs; i++) {
+    const t0 = performance.now();
+    await fn();
+    ms.push(Math.round(performance.now() - t0));
+  }
+  const med = median(ms);
+  console.log(`${label.padEnd(48)} median ${String(med).padStart(6)}ms   (runs: ${ms.join(', ')})`);
+  return med;
+}
+
+async function ttftOpenRouter(pinned: boolean): Promise<void> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY non impostata');
+  const controller = new AbortController();
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: process.env.NEXT_PUBLIC_DEFAULT_MODEL_ID || 'deepseek/deepseek-v4-flash',
+      messages: [{ role: 'user', content: QUERY }],
+      stream: true,
+      max_tokens: 16,
+      ...(pinned && { provider: { sort: 'latency' } }),
+    }),
+    signal: controller.signal,
+  });
+  if (!res.ok) throw new Error(`OpenRouter ${res.status}`);
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (decoder.decode(value).includes('"content"')) break;
+  }
+  controller.abort();
+}
+
+async function embedOnly(): Promise<void> {
+  const apiKey = process.env.OPENROUTER_API_KEY!;
+  const openrouter = createOpenRouter({ apiKey });
+  await embed({ model: openrouter.textEmbeddingModel(EMBEDDING_MODEL), value: QUERY });
+}
+
+async function main() {
+  console.log('— Baseline latenza pipeline Quily —\n');
+  const ropts = {
+    embeddingProvider: 'openrouter' as const,
+    embeddingApiKey: process.env.OPENROUTER_API_KEY,
+    cohereApiKey: process.env.COHERE_API_KEY,
+  };
+  await time('embedQuery (OpenRouter bge-m3)', () => embedOnly());
+  await time('retrieveWithReranking (embed+pgvector+rerank)', () => retrieveWithReranking(QUERY, ropts));
+  await time('prepareQuery (full RAG prep)', () =>
+    prepareQuery({ query: QUERY, conversationHistory: [], ...ropts }));
+  await time('TTFT chat OpenRouter (default routing)', () => ttftOpenRouter(false));
+  await time('TTFT chat OpenRouter (sort:latency)', () => ttftOpenRouter(true));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/lib/rag/cloudflare-reranker.ts
+++ b/src/lib/rag/cloudflare-reranker.ts
@@ -6,7 +6,10 @@
 
 const CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4/accounts';
 const MODEL_ID = '@cf/baai/bge-reranker-base';
-const REQUEST_TIMEOUT_MS = 10000;
+// Default rerank budget. Observed p50 is ~300-600ms; the old 10s ceiling let a slow Cloudflare
+// queue block the entire chat response. 1200ms trims only the pathological tail — the caller
+// (retriever.ts) already falls back to similarity ordering on abort, as it does on any error.
+const DEFAULT_RERANK_TIMEOUT_MS = 1200;
 
 interface CloudflareResponse {
   result: { response: Array<{ id: number; score: number }> };
@@ -24,7 +27,8 @@ export async function rerankWithCloudflare(
   documents: string[],
   topK: number,
   accountId: string,
-  apiToken: string
+  apiToken: string,
+  timeoutMs: number = DEFAULT_RERANK_TIMEOUT_MS
 ): Promise<RerankResult[]> {
   // Input validation
   if (!query.trim() || documents.length === 0) {
@@ -35,7 +39,7 @@ export async function rerankWithCloudflare(
   const url = `${CLOUDFLARE_API_BASE}/${accountId}/ai/run/${MODEL_ID}`;
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetch(url, {

--- a/src/lib/rag/retriever.ts
+++ b/src/lib/rag/retriever.ts
@@ -11,6 +11,11 @@ import { rerankWithCloudflare } from './cloudflare-reranker';
 const UNIFIED_EMBEDDING_MODEL = 'baai/bge-m3';
 const CHUTES_EMBEDDING_MODEL_SLUG = 'chutes-baai-bge-m3';
 
+// Rerank budget shared by both providers. Reranking is a fail-safe refinement, not a hard
+// dependency: on timeout the code below falls back to similarity ordering (same as on error).
+// Cohere's SDK exposes no timeout, so it's wrapped in a Promise.race; Cloudflare takes it as a param.
+const RERANK_TIMEOUT_MS = 1200;
+
 // Temporal keywords that indicate the user wants recent content
 // Includes translations for major languages to support multilingual queries
 const TEMPORAL_KEYWORDS = [
@@ -685,12 +690,17 @@ export async function retrieveWithReranking(
   if (resolvedCohereKey) {
     try {
       const cohereProvider = createCohere({ apiKey: resolvedCohereKey });
-      const { ranking } = await rerank({
-        model: cohereProvider.reranking('rerank-v3.5'),
-        query,
-        documents: candidates.map((c: { content: string }) => c.content),
-        topN: rerankTopN,
-      });
+      const { ranking } = await Promise.race([
+        rerank({
+          model: cohereProvider.reranking('rerank-v3.5'),
+          query,
+          documents: candidates.map((c: { content: string }) => c.content),
+          topN: rerankTopN,
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Cohere rerank timeout')), RERANK_TIMEOUT_MS)
+        ),
+      ]);
       return mergeWithReserved(mapRankedToChunks(ranking));
     } catch (cohereError) {
       console.warn('Cohere reranking failed, trying Cloudflare:', cohereError);
@@ -709,7 +719,8 @@ export async function retrieveWithReranking(
         candidates.map((c: { content: string }) => c.content),
         rerankTopN,
         cloudflareAccountId,
-        cloudflareApiToken
+        cloudflareApiToken,
+        RERANK_TIMEOUT_MS
       );
       if (ranking.length > 0) {
         return mergeWithReserved(mapRankedToChunks(

--- a/src/lib/rag/retriever.ts
+++ b/src/lib/rag/retriever.ts
@@ -308,10 +308,18 @@ async function generateEmbedding(
     return getChutesEmbedding(text, accessToken);
   }
   if (!apiKey) throw new Error('OpenRouter API key is required for embeddings');
+  // Provider pinning on the query embedding: bge-m3 is deterministic, so the vectors stay
+  // compatible with the index (verified via retrieval-parity, task 2026-07-10). This prevents
+  // OpenRouter from routing to a slow provider — the query embed was measured at ~870ms median
+  // with high variance (a known DeepInfra failure mode on kaya showed 13-80s tails).
+  // Toggle: OPENROUTER_EMBED_ORDER="" disables pinning without touching code.
+  const embedOrder = (process.env.OPENROUTER_EMBED_ORDER ?? 'SiliconFlow,DeepInfra')
+    .split(',').map((s) => s.trim()).filter(Boolean);
   const openrouter = createOpenRouter({ apiKey });
   const result = await embed({
     model: openrouter.textEmbeddingModel(
-      model || process.env.OPENROUTER_EMBEDDING_MODEL || UNIFIED_EMBEDDING_MODEL
+      model || process.env.OPENROUTER_EMBEDDING_MODEL || UNIFIED_EMBEDDING_MODEL,
+      embedOrder.length > 0 ? { provider: { order: embedOrder } } : undefined
     ),
     value: text,
   });


### PR DESCRIPTION
Reduces time-to-first-token on the web chat path. Measurement showed the LLM call dominated: default OpenRouter routing had a TTFT p50 of ~4.4s with a worst run of ~11s. Pinning the provider by latency cuts that to ~0.7s and removes the tail.

## Highlights

**LLM provider pinning (biggest win)** — the web streaming route now routes OpenRouter by `sort: 'latency'` with a quantization allowlist that excludes fp4 backends (so speed doesn't cost answer quality). The bot/Discord path already pinned providers; this closes the same gap on the path users actually hit.

**Embedding provider pinning** — the query embedding (runs on every request) was ~870ms with high variance from unpinned routing. Pinned to `SiliconFlow,DeepInfra`: ~630ms with tight variance. Retrieval parity verified identical before/after (bge-m3 is deterministic, so the index stays compatible).

**Rerank timeouts** — Cloudflare rerank drops from a 10s ceiling to 1200ms; Cohere gains a 1200ms timeout it never had. Both fall back to similarity ordering on timeout, the same path already used on error. Calibrated from measured p50 (~270-515ms) with an ~8.5s tail the old ceiling let block responses.

**Observability** — a `[chat] timing rag=..ms first_token=..ms` line is logged at the first token in both provider paths, so stage regressions are visible in runtime logs.

Both pinning behaviors are on by default from code and can be overridden or disabled via `OPENROUTER_SORT` and `OPENROUTER_EMBED_ORDER` (documented in `.env.example`).

## Commits
- chore(latency): per-stage measurement script for chat pipeline
- perf(chat): pin OpenRouter provider by latency on web streaming path
- perf(embedding): pin OpenRouter provider order for query embeddings
- perf(rerank): 1200ms timeout on Cohere and Cloudflare with similarity fallback
- feat(chat): per-phase timing log at first token
- docs(env): document OPENROUTER_SORT and OPENROUTER_EMBED_ORDER latency toggles