### PR TITLE
ci: run workflows on Node 22 for supabase-js

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          # 22+ required: @supabase/supabase-js needs a native WebSocket, which
+          # Node 20 lacks ("Node.js detected but native WebSocket not found").
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/sync-techtree.yml
+++ b/.github/workflows/sync-techtree.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          # 22+ required: @supabase/supabase-js needs a native WebSocket, which
+          # Node 20 lacks ("Node.js detected but native WebSocket not found").
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
Follow-up to #104, which unmasked this.

With corepack fixed, `Daily Docs Sync` got all the way to **Run RAG ingestion** and failed there:

```
⚠️  Node.js 20 and below are deprecated ... @supabase/supabase-js
✖ Ingestion failed
Error: Node.js detected but native WebSocket not found.
Suggested solution: Ensure you are running Node.js 22+
```

Cause: the Berry migration regenerated the lockfile (6939 lines changed), pulling a newer `@supabase/supabase-js` that needs a native WebSocket. Node 20 doesn't have one.

**No data was lost** — it failed on `Checking for orphaned chunks` (a read), before `--clean` deletes anything. Verified with `yarn ingest:count`: 993 chunks still in the DB.

`sync-techtree.yml` has the same latent bug; its dispatch passed today only because the tech tree was unchanged so the ingest step was skipped.

Node 22 matches the local dev environment (v22.23.1). Vercel already runs Node 24, so the app itself was never affected.